### PR TITLE
to deal with cell_states which has '+' or space in their name

### DIFF
--- a/Scripts/5_DEA/edgeR_DEgenes_allstates_STEP7.1.ipynb
+++ b/Scripts/5_DEA/edgeR_DEgenes_allstates_STEP7.1.ipynb
@@ -990,9 +990,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Takes a while (around 10 min with my environment). There may be more efficient code... \n",
     "LIST_COLNAMES=[]\n",
     "for MUTATION in MUTATIONS:\n",
-    "    OUT=np.where([re.match(MUTATION, COLNAME) for COLNAME in x.columns])[0]\n",
+    "    otherMUTATIONS = list(set(MUTATIONS) - set([MUTATION]))\n",
+    "    OUT=np.array([i for i in range(len(x.columns)) \\\n",
+    "                  if (MUTATION in x.columns[i]) & \\\n",
+    "                     (all([mut not in x.columns[i] for mut in otherMUTATIONS if mut not in MUTATION])) # to prevent unspecific picking (e.g. 'B' and 'B_plasma', 'MY1' and 'MY11')\n",
+    "                 ])\n",
     "    LIST_COLNAMES.append(OUT)\n",
     "\n",
     "x=[x.iloc[:,i].mean(axis=1) for i in LIST_COLNAMES] # Mean per Genotype_Cellstate\n",
@@ -1969,7 +1974,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/Scripts/5_DEA/edgeR_DEgenes_allstates_STEP7.2.ipynb
+++ b/Scripts/5_DEA/edgeR_DEgenes_allstates_STEP7.2.ipynb
@@ -25,9 +25,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x=read.csv(\"/fast/AG_Huebner/huebner3/ANALYSES/20190926_gp_BadOyenhausen/scanpy/20210302/Global_touse/ALL_CELLSTATE_PSEUDOBULK_LV.csv\")\n",
-    "genes_tofilter=read.csv(\"/fast/AG_Huebner/huebner3/ANALYSES/20190926_gp_BadOyenhausen/scanpy/20210302/Global_touse/ALL_CELLSTATE_PSEUDOBULK_FILTERING_LV.csv\")\n",
+    "x=read.csv(\"/fast/AG_Huebner/huebner3/ANALYSES/20190926_gp_BadOyenhausen/scanpy/20210302/Global_touse/ALL_CELLSTATE_PSEUDOBULK_LV.csv\", check.names=FALSE)\n",
+    "genes_tofilter=read.csv(\"/fast/AG_Huebner/huebner3/ANALYSES/20190926_gp_BadOyenhausen/scanpy/20210302/Global_touse/ALL_CELLSTATE_PSEUDOBULK_FILTERING_LV.csv\", check.names=FALSE)\n",
     "colnames(genes_tofilter) <- gsub(\"mutation.negative\", 'PVneg', colnames(genes_tofilter))\n",
+    "colnames(genes_tofilter)[1]='X' # since check.names=FALSE remove 'X' from the first column name\n",
     "\n",
     "# Only needed for the column cell_state\n",
     "CELLTYPE_STATE <- read.csv(\"/fast/AG_Huebner/huebner3/ANALYSES/20190926_gp_BadOyenhausen/scanpy/20210302/Global_touse/CELLSTATE_TRANSLATION_TABLE.csv\")\n",
@@ -1972,7 +1973,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.1"
+   "version": "4.0.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi,
the issues are caused by cell_states naming that include ‘+’ or ‘space’ (such as CD4+T and CD16+ Mo). I guess these naming are only in immune cells.

In STEP7.1 the step making table for filtering, re.match is not working for the cell_states which has + and returning NaN. This causes weird return when you do filtering in STEP7.2 and in final_df the values of ‘mean_exp_control’ and ‘mean_exp_genotype’ shows NA.

In STEP7.2, read.csv() in R replaces '+'  (and space) in header with '.' but doesn’t replace when '+' is in an element of the table. So cell_state names in CELLSTATE_TRANSLATION_TABLE are intact. This discrepancy causes the ‘nan’ in the DEG table cell_type column and causes losing those cell states when you select as cell_type=='Lymphoid' or cell_type=='Myeloid'. 
Adding check.names=FALSE in read.csv() seems prevent the replacing.

Another option would be changing cell_states name (remove ‘+’ or space) and keep the code as the current version. This may prevent similar problem in future.